### PR TITLE
Force using Python2 and bugfixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ deps:
 install: deps install-binaries install-unit
 
 install-binaries:
-	touch /etc/avahi/aliases
+	sudo touch /etc/avahi/aliases
 	sudo cp bin/avahi* /usr/local/bin
 
 install-unit:

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ deps:
 install: deps install-binaries install-unit
 
 install-binaries:
+	touch /etc/avahi/aliases
 	sudo cp bin/avahi* /usr/local/bin
 
 install-unit:

--- a/Makefile
+++ b/Makefile
@@ -8,14 +8,14 @@ install-binaries:
 	sudo cp bin/avahi* /usr/local/bin
 
 install-unit:
-	@echo ">>> Installing systemd unit"
+	@echo "\n>>> Installing systemd unit"
 	sudo cp etc/avahi-alias.service /etc/systemd/system/
 	sudo systemctl daemon-reload
-	@echo ">>> Enabling systemd unit"
+	@echo "\n>>> Enabling systemd unit"
 	sudo systemctl enable avahi-alias.service
 	sudo systemctl restart avahi-alias.service
 	sudo systemctl status avahi-alias.service
-	@echo ">>> Install done.\n Add aliases to /etc/avahi/aliases or /etc/avahi/aliases.d/* and use\n    sudo systemctl <start|stop|status> avahi-alias.service\n"
+	@echo "\n>>> Install done.\n Add aliases to /etc/avahi/aliases or /etc/avahi/aliases.d/* and use\n    sudo systemctl <start|stop|status> avahi-alias.service\n"
 
 uninstall-unit:
 	@echo ">>> Uninstallling systemd unit"

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 deps:
-	sudo apt install python-avahi python-dbus
+	sudo apt install -y python-avahi python-dbus
 
 install: deps install-binaries install-unit
 

--- a/bin/avahi-add-alias
+++ b/bin/avahi-add-alias
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
+
 import os, sys
 from subprocess import Popen, PIPE
 

--- a/bin/avahi-list-aliases
+++ b/bin/avahi-list-aliases
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import os, sys
 from subprocess import Popen

--- a/bin/avahi-list-aliases
+++ b/bin/avahi-list-aliases
@@ -23,4 +23,4 @@ for line in alias_file:
         aliases.add(entry)
 
 for alias in aliases:
-    print alias 
+    print(alias)

--- a/bin/avahi-publish-aliases
+++ b/bin/avahi-publish-aliases
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python2
 
 import os, sys
 from subprocess import Popen

--- a/bin/avahi-publish-aliases
+++ b/bin/avahi-publish-aliases
@@ -10,20 +10,18 @@ def ensure_file(path):
         rfile = open(path,"w+");
     return rfile
 
-
 command = '/usr/local/bin/avahi-publish-domain-alias'
 alias_pid_path = "/tmp/avahi-publish-alias.pid"
 alias_file_path = "/etc/avahi/aliases"
 alias_dir_glob = "/etc/avahi/aliases.d/*"
 
 alias_file = open(alias_file_path)
+
 if not os.path.exists(alias_pid_path):
     open(alias_pid_path,"w").close()
 
 alias_dir = glob.glob(alias_dir_glob)
-
 alias_pid = open(alias_pid_path,"r")
-
 aliases = set()
 
 for line in alias_pid:

--- a/bin/avahi-publish-domain-alias
+++ b/bin/avahi-publish-domain-alias
@@ -1,5 +1,4 @@
-#! /usr/bin/env python
-# avahi-alias.py
+#!/usr/bin/env python2
 
 import avahi, dbus
 from encodings.idna import ToASCII

--- a/bin/avahi-remove-alias
+++ b/bin/avahi-remove-alias
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
+
 import os,sys
 from subprocess import Popen, PIPE
 import glob

--- a/bin/avahi-remove-alias
+++ b/bin/avahi-remove-alias
@@ -12,6 +12,7 @@ alias_dir = glob.glob(alias_dir_glob)
 for alias in args:
     alias_file = open("/etc/avahi/aliases")
     alias_output = []
+
     for line in alias_file:
         line = line.rstrip("\n")
         if line != alias:

--- a/bin/avahi-remove-alias
+++ b/bin/avahi-remove-alias
@@ -13,6 +13,7 @@ for alias in args:
     alias_file = open("/etc/avahi/aliases")
     alias_output = []
     for line in alias_file:
+        line = line.rstrip("\n")
         if line != alias:
             alias_output.append(line)
 


### PR DESCRIPTION
This PR forces this lib to use Python 2 since `python-avahi` is not available for Python 3 yet.

Also, fixes #1 and #2